### PR TITLE
refactor!: use variation_normalizer python api

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ UTA_DB_URL=driver://user:password@host:port/database/schema
 AWS_ACCESS_KEY_ID=dummy
 AWS_SECRET_ACCESS_KEY=dummy
 AWS_SESSION_TOKEN=dummy
-PARSED_TO_CN_VAR_ENDPOINT=http://normalize.cancervariants.org/variation/parsed_to_cn_var
 ```
 
 ### Running the Variation Normalizer

--- a/analysis/cnvs/parse_prep_normalize_nch_cnvs.ipynb
+++ b/analysis/cnvs/parse_prep_normalize_nch_cnvs.ipynb
@@ -4,30 +4,61 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "import pandas as pd\n",
-    "import numpy as np\n",
-    "from tqdm.notebook import tqdm\n",
-    "import os\n",
-    "import re\n",
-    "import requests\n",
-    "import json\n",
-    "from dotenv import load_dotenv"
+    "from dotenv import load_dotenv\n",
+    "# Environment variables are set for gene-normalizer dynamodb instance and\n",
+    "# UTA DB credentials\n",
+    "load_dotenv()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/kxk102/Documents/genomic_med_lab/variation-normalizer-manuscript/.venv/lib/python3.11/site-packages/python_jsonschema_objects/__init__.py:46: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
    "source": [
-    "pd.set_option('max_columns',100)"
+    "import json\n",
+    "import re\n",
+    "\n",
+    "import pandas as pd\n",
+    "from tqdm.notebook import tqdm\n",
+    "from variation.main import parsed_to_cn_var\n",
+    "from variation.schemas.copy_number_schema import ParsedToCnVarQuery"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.set_option('display.max_columns',100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -37,7 +68,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +135,7 @@
        "4         16p12.1(27864452_27995317)x3  GRCh37"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,7 +146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -124,7 +155,7 @@
        "19106"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -142,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -151,7 +182,7 @@
        "14710"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -170,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -190,7 +221,7 @@
        "       '1919'], dtype=object)"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +258,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,11 +283,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def count_positions(v: str)-> int: \n",
+    "def count_positions(v: str)-> int:\n",
     "    '''given an ISCN nomenclature string, returns the number of numerical positions detected (expected is 2 per the nomenclature)'''\n",
     "    numranges = re.findall(\"\\([\\d,\\-\\_]+\\)\",v)[0]\n",
     "    numranges = re.sub(',','',numranges)\n",
@@ -277,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -417,7 +448,7 @@
        "17398         129951769            621197 -129330571           3  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -428,7 +459,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -437,7 +468,7 @@
        "14702"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -457,7 +488,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -729,7 +760,7 @@
        "19032   230250520  203387006  -26863513           2  "
       ]
      },
-     "execution_count": 16,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -740,7 +771,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -749,7 +780,7 @@
        "14683"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -768,7 +799,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,7 +817,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -809,7 +840,7 @@
        " '5~6']"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -820,7 +851,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -829,7 +860,7 @@
        "[0, 1, 2, 3, 4, 5]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -840,7 +871,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -849,7 +880,7 @@
        "[0, 1, 2, 3, 4, 5, 6]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -868,33 +899,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
     "da['region_of_homozygosity'] = da['variant'].str.contains('hmz')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False    9017\n",
-       "True     5666\n",
-       "Name: region_of_homozygosity, dtype: int64"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "da['region_of_homozygosity'].value_counts()"
    ]
   },
   {
@@ -905,10 +914,33 @@
     {
      "data": {
       "text/plain": [
-       "9017"
+       "region_of_homozygosity\n",
+       "False    9017\n",
+       "True     5666\n",
+       "Name: count, dtype: int64"
       ]
      },
      "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "da['region_of_homozygosity'].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "9017"
+      ]
+     },
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -920,7 +952,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1259,7 +1291,7 @@
        "16695                2                   False  "
       ]
      },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1282,7 +1314,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1291,7 +1323,7 @@
        "9000"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1313,7 +1345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -1322,7 +1354,7 @@
        "8989"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1334,7 +1366,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1351,55 +1383,63 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "load_dotenv()\n",
-    "endpoint_url = os.environ.get(\"PARSED_TO_CN_VAR_ENDPOINT\")"
-   ]
-  },
-  {
-   "cell_type": "code",
    "execution_count": 30,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4a67496753de459399f0d6219b35992b",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/8989 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "### this cell runs the normalizer and saves the output\n",
-    "### runs in ~12min (uncomment to run)\n",
-    "### skip to next cell to avoid re-running\n",
+    "### runs in ~40s\n",
+    "### skip re-running by commenting out this cell\n",
     "\n",
-    "#norm_responses = []\n",
-    "#for ix,cnv in tqdm(da.iterrows(), total=len(da)):\n",
-    "#    args = {\n",
-    "#        'assembly': cnv['build'],\n",
-    "#        'chromosome': f\"chr{cnv['chromosome']}\",\n",
-    "#        'start0': int(cnv['start']),\n",
-    "#        'start_pos_type': 'Number',\n",
-    "#        'end0': int(cnv['stop']),\n",
-    "#        'end_pos_type': 'Number'\n",
-    "#    }\n",
-    "#    if cnv['copy_number_min'] == cnv['copy_number_max']: ##if copy number is unambiguous, not a range\n",
-    "#        args['copies0'] = int(cnv['copy_number_min'])\n",
-    "#        args['copies_type'] = 'Number'\n",
-    "#    else: ##if copy number is a range e.g. 3~4\n",
-    "#        args['copies0'] = int(cnv['copy_number_min'])\n",
-    "#        args['copies1'] = int(cnv['copy_number_max'])\n",
-    "#        args['copies_type'] = 'DefiniteRange'\n",
-    "#        \n",
-    "#    args['do_liftover'] = True\n",
-    "#    args['untranslatable_returns_text'] = False\n",
-    "#\n",
-    "#    rec = dict(cnv)\n",
-    "#    rec.update(requests.post(endpoint_url, json=args).json())\n",
-    "#    \n",
-    "#    for arg,val in args.items():\n",
-    "#        rec[f\"query_args.{arg}\"] = val\n",
-    "#    norm_responses.append(rec)\n",
-    "    \n",
-    "### save raw normalizer output\n",
-    "#with open('cnv_data/NCH-normalizer-results.json', 'w') as f:\n",
-    "#    json.dump(norm_responses, f)"
+    "norm_responses = []\n",
+    "for ix,cnv in tqdm(da.iterrows(), total=len(da)):\n",
+    "    args = {\n",
+    "        'assembly': cnv['build'],\n",
+    "        'chromosome': f\"chr{cnv['chromosome']}\",\n",
+    "        'start0': int(cnv['start']),\n",
+    "        'start_pos_type': 'Number',\n",
+    "        'end0': int(cnv['stop']),\n",
+    "        'end_pos_type': 'Number'\n",
+    "    }\n",
+    "    if cnv['copy_number_min'] == cnv['copy_number_max']: ##if copy number is unambiguous, not a range\n",
+    "        args['copies0'] = int(cnv['copy_number_min'])\n",
+    "        args['copies_type'] = 'Number'\n",
+    "    else: ##if copy number is a range e.g. 3~4\n",
+    "        args['copies0'] = int(cnv['copy_number_min'])\n",
+    "        args['copies1'] = int(cnv['copy_number_max'])\n",
+    "        args['copies_type'] = 'DefiniteRange'\n",
+    "\n",
+    "    args['do_liftover'] = True\n",
+    "    args['untranslatable_returns_text'] = False\n",
+    "\n",
+    "    rec = dict(cnv)\n",
+    "    resp = json.loads(parsed_to_cn_var(ParsedToCnVarQuery(**args)).json())\n",
+    "    rec.update(resp)\n",
+    "\n",
+    "    for arg,val in args.items():\n",
+    "        rec[f\"query_args.{arg}\"] = val\n",
+    "\n",
+    "    norm_responses.append(rec)\n",
+    "\n",
+    "\n",
+    "## save raw normalizer output\n",
+    "with open('cnv_data/NCH-normalizer-results.json', 'w') as f:\n",
+    "   json.dump(norm_responses, f)"
    ]
   },
   {
@@ -1464,9 +1504,9 @@
        "      <th>service_meta_.response_datetime</th>\n",
        "      <th>service_meta_.name</th>\n",
        "      <th>service_meta_.url</th>\n",
-       "      <th>copy_number_count._id</th>\n",
+       "      <th>copy_number_count.id</th>\n",
        "      <th>copy_number_count.type</th>\n",
-       "      <th>copy_number_count.subject._id</th>\n",
+       "      <th>copy_number_count.subject.id</th>\n",
        "      <th>copy_number_count.subject.type</th>\n",
        "      <th>copy_number_count.subject.sequence_id</th>\n",
        "      <th>copy_number_count.subject.interval.type</th>\n",
@@ -1508,7 +1548,7 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>0.6.0-dev0</td>\n",
-       "      <td>2023-09-08T20:45:57.626952</td>\n",
+       "      <td>2023-10-23T14:06:02.203507</td>\n",
        "      <td>variation-normalizer</td>\n",
        "      <td>https://github.com/cancervariants/variation-no...</td>\n",
        "      <td>ga4gh:CN.3ngQpUFdG3tM_Rl9qmmMCOmouQ56RzVh</td>\n",
@@ -1553,7 +1593,7 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>0.6.0-dev0</td>\n",
-       "      <td>2023-09-08T20:45:57.697741</td>\n",
+       "      <td>2023-10-23T14:06:02.218008</td>\n",
        "      <td>variation-normalizer</td>\n",
        "      <td>https://github.com/cancervariants/variation-no...</td>\n",
        "      <td>ga4gh:CN.a7N46875Fg6ByqLSWGdJG-svWNNAcr9k</td>\n",
@@ -1598,7 +1638,7 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>0.6.0-dev0</td>\n",
-       "      <td>2023-09-08T20:45:57.767167</td>\n",
+       "      <td>2023-10-23T14:06:02.230645</td>\n",
        "      <td>variation-normalizer</td>\n",
        "      <td>https://github.com/cancervariants/variation-no...</td>\n",
        "      <td>ga4gh:CN.5Q6YaAWsS0C4cu1FwV2oJKF-AqTB_2bz</td>\n",
@@ -1643,7 +1683,7 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>0.6.0-dev0</td>\n",
-       "      <td>2023-09-08T20:45:57.837083</td>\n",
+       "      <td>2023-10-23T14:06:02.241352</td>\n",
        "      <td>variation-normalizer</td>\n",
        "      <td>https://github.com/cancervariants/variation-no...</td>\n",
        "      <td>ga4gh:CN.vQsEm4mE9ThdU2JmWw6b5nV16XVJWr8g</td>\n",
@@ -1688,7 +1728,7 @@
        "      <td>True</td>\n",
        "      <td>False</td>\n",
        "      <td>0.6.0-dev0</td>\n",
-       "      <td>2023-09-08T20:45:57.911750</td>\n",
+       "      <td>2023-10-23T14:06:02.250986</td>\n",
        "      <td>variation-normalizer</td>\n",
        "      <td>https://github.com/cancervariants/variation-no...</td>\n",
        "      <td>ga4gh:CN.4DSnP3K7tc2CFawT5Zyv9kGRers_O2Ko</td>\n",
@@ -1763,11 +1803,11 @@
        "4                                   False            0.6.0-dev0   \n",
        "\n",
        "  service_meta_.response_datetime    service_meta_.name  \\\n",
-       "0      2023-09-08T20:45:57.626952  variation-normalizer   \n",
-       "1      2023-09-08T20:45:57.697741  variation-normalizer   \n",
-       "2      2023-09-08T20:45:57.767167  variation-normalizer   \n",
-       "3      2023-09-08T20:45:57.837083  variation-normalizer   \n",
-       "4      2023-09-08T20:45:57.911750  variation-normalizer   \n",
+       "0      2023-10-23T14:06:02.203507  variation-normalizer   \n",
+       "1      2023-10-23T14:06:02.218008  variation-normalizer   \n",
+       "2      2023-10-23T14:06:02.230645  variation-normalizer   \n",
+       "3      2023-10-23T14:06:02.241352  variation-normalizer   \n",
+       "4      2023-10-23T14:06:02.250986  variation-normalizer   \n",
        "\n",
        "                                   service_meta_.url  \\\n",
        "0  https://github.com/cancervariants/variation-no...   \n",
@@ -1776,14 +1816,14 @@
        "3  https://github.com/cancervariants/variation-no...   \n",
        "4  https://github.com/cancervariants/variation-no...   \n",
        "\n",
-       "                       copy_number_count._id copy_number_count.type  \\\n",
+       "                        copy_number_count.id copy_number_count.type  \\\n",
        "0  ga4gh:CN.3ngQpUFdG3tM_Rl9qmmMCOmouQ56RzVh        CopyNumberCount   \n",
        "1  ga4gh:CN.a7N46875Fg6ByqLSWGdJG-svWNNAcr9k        CopyNumberCount   \n",
        "2  ga4gh:CN.5Q6YaAWsS0C4cu1FwV2oJKF-AqTB_2bz        CopyNumberCount   \n",
        "3  ga4gh:CN.vQsEm4mE9ThdU2JmWw6b5nV16XVJWr8g        CopyNumberCount   \n",
        "4  ga4gh:CN.4DSnP3K7tc2CFawT5Zyv9kGRers_O2Ko        CopyNumberCount   \n",
        "\n",
-       "                copy_number_count.subject._id copy_number_count.subject.type  \\\n",
+       "                 copy_number_count.subject.id copy_number_count.subject.type  \\\n",
        "0  ga4gh:VSL.Z7qY7FVvn1B9Fnm5uOlKNFjBi2HNZYJy               SequenceLocation   \n",
        "1  ga4gh:VSL.UD-2VYWImOjJkIo86ZdoR5MVnNna7S4m               SequenceLocation   \n",
        "2  ga4gh:VSL.Dv73cYS1iBXWkaInIZ2sopcqJfM6R2aA               SequenceLocation   \n",
@@ -1871,7 +1911,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## warnings were stored in a list; convert to a string for readability/ease of processing \n",
+    "## warnings were stored in a list; convert to a string for readability/ease of processing\n",
     "dr['warning_string'] = dr['warnings'].apply(';'.join)"
    ]
   },
@@ -1883,11 +1923,12 @@
     {
      "data": {
       "text/plain": [
-       "Success                                            8685\n",
-       "Unable to liftover: chr# with pos #                 208\n",
-       "Position # is not valid on ga4gh:SQ.*                63\n",
-       "Unhandled exception. See logs for more details.      33\n",
-       "Name: warning_string_reduce, dtype: int64"
+       "warning_string_reduce\n",
+       "Success                                  8685\n",
+       "Unable to liftover: chr# with pos #       208\n",
+       "Position # is not valid on ga4gh:SQ.*      63\n",
+       "Pydantic Validation Error                  33\n",
+       "Name: count, dtype: int64"
       ]
      },
      "execution_count": 34,
@@ -1904,7 +1945,9 @@
     "    warning = re.sub('chr[XY\\d]+','chr#',warning)\n",
     "    warning = re.sub('\\(\\d+\\)','#',warning)\n",
     "    warning = re.sub('pos \\d+','pos #',warning)\n",
-    "    \n",
+    "    if re.match(r\"\\d+ validation errors for\", warning):\n",
+    "        warning = \"Pydantic Validation Error\"\n",
+    "\n",
     "    if warning=='':\n",
     "        return 'Success'\n",
     "    return warning\n",
@@ -1984,7 +2027,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Close #44 

Replaces existing code which uses REST API. We are switching to using the python package for reproducibility.

Once merged, I will update the files in the s3 bucket. `_id` was changed to `id`. If this file is used in other places, we'll need to re-run those notebooks. 