### PR TITLE
refactor: clean up civic variation analysis

### DIFF
--- a/analysis/civic/variation_analysis/civic_variation_analysis.ipynb
+++ b/analysis/civic/variation_analysis/civic_variation_analysis.ipynb
@@ -12,25 +12,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/kxk102/Documents/genomic_med_lab/folder-migration/variation-normalizer-manuscript/.venv/lib/python3.11/site-packages/python_jsonschema_objects/__init__.py:49: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
+      "/Users/kxk102/Documents/genomic_med_lab/variation-normalizer-manuscript/.venv/lib/python3.11/site-packages/python_jsonschema_objects/__init__.py:46: UserWarning: Schema version http://json-schema.org/draft-07/schema not recognized. Some keywords and features may not be supported.\n",
       "  warnings.warn(\n"
      ]
     }
    ],
    "source": [
     "import logging\n",
-    "from enum import Enum\n",
+    "from enum import StrEnum\n",
     "import re\n",
     "import csv\n",
     "from pathlib import Path\n",
     "import zipfile\n",
+    "from typing import Dict, Set, Tuple, Optional\n",
     "\n",
     "from civicpy import civic as civicpy\n",
     "from dotenv import load_dotenv\n",
@@ -43,7 +44,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
@@ -52,7 +53,7 @@
        "True"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -65,24 +66,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "***Using Gene Database Endpoint: http://localhost:8000***\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "query_handler = QueryHandler()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -108,7 +101,7 @@
        "True"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -126,34 +119,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'Total Number of variants in CIViC: 3519'"
+       "'Total Number of accepted and submitted variants in CIViC: 3519'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "variants = civicpy.get_all_variants(include_status=[\"accepted\", \"submitted\"])\n",
-    "total_variants = len(variants)\n",
-    "f\"Total Number of variants in CIViC: {total_variants}\""
+    "acc_sub_variants = civicpy.get_all_variants(include_status=[\"accepted\", \"submitted\"])\n",
+    "len_acc_sub_variants = len(acc_sub_variants)\n",
+    "f\"Total Number of accepted and submitted variants in CIViC: {len_acc_sub_variants}\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
-    "class VariantCategory(str, Enum):\n",
-    "    \"\"\"Create enum for the kind of variants that are in CIViC.\"\"\"\n",
+    "class NotSupportedVariantCategory(StrEnum):\n",
+    "    \"\"\"Create enum for the kind of variants that are not supported by the variation-normalizer.\"\"\"\n",
     "\n",
     "    EXPRESSION = \"Expression Variants\"\n",
     "    EPIGENETIC_MODIFICATION = \"Epigenetic Modification\"\n",
@@ -173,12 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Transcript Variants we did not attempt to normalize due to no input query available \n",
-    "These are CIViC Variants where we did not attempt to normalize since we cannot find a \n",
-    "free text or HGVS-like expression to use. One example would be a CIViC Variant whose \n",
-    "name has \"c.\" in it. In this case, we want the genomic representative. First, we look at the \n",
-    "HGVS expressions to find a genomic expression. If there is no genomic HGVS expression, we try using the CIViC representative variant coordinates. If neither exist,\n",
-    "we do not even attempt to normalize. These are under the Transcript Variant category."
+    "Did not attempt to normalize `NotSupportedVariantCategory.TRANSCRIPT_VAR` due to no input query available. These are CIViC genomic variants (\"c.\" in variant name) with no genomic HGVS expression or representative coordinates."
    ]
   },
   {
@@ -186,17 +174,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Below are terms in CIViC that we know that the variation normalizer cannot support."
+    "Below are variant names in CIViC that we know that the variation normalizer cannot support."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
     "not_supported = {\n",
-    "    VariantCategory.EXPRESSION: {\n",
+    "    NotSupportedVariantCategory.EXPRESSION: {\n",
     "        \"overexpression\",\n",
     "        \"expression\",\n",
     "        \"underexpression\",\n",
@@ -208,14 +196,14 @@
     "        \"low ratio of vegf165b/vegftotal\",\n",
     "        \"lgr5fl\",\n",
     "    },\n",
-    "    VariantCategory.EPIGENETIC_MODIFICATION: {\n",
+    "    NotSupportedVariantCategory.EPIGENETIC_MODIFICATION: {\n",
     "        \"methylation\",\n",
     "        \"promoter hypermethylation\",\n",
     "        \"promoter methylation\",\n",
     "        \"phosphorylation\",\n",
     "    },\n",
-    "    VariantCategory.FUSION: {\"::\", \"fusion\"},\n",
-    "    VariantCategory.SEQUENCE_VARS: {\n",
+    "    NotSupportedVariantCategory.FUSION: {\"::\", \"fusion\"},\n",
+    "    NotSupportedVariantCategory.SEQUENCE_VARS: {\n",
     "        \"frameshift truncation\",\n",
     "        \"frameshift\",\n",
     "        \"frame shift\",\n",
@@ -229,7 +217,7 @@
     "        \"ex19 del l858r\",\n",
     "        \"single nucleotide variant\",\n",
     "    },\n",
-    "    VariantCategory.GENE_FUNC: {\n",
+    "    NotSupportedVariantCategory.GENE_FUNC: {\n",
     "        \"gain of function\",\n",
     "        \"gain-of-function\",\n",
     "        \"loss of function\",\n",
@@ -240,7 +228,7 @@
     "        \"null\",\n",
     "        \"viii\",\n",
     "    },\n",
-    "    VariantCategory.REARRANGEMENTS: {\n",
+    "    NotSupportedVariantCategory.REARRANGEMENTS: {\n",
     "        \"translocation\",\n",
     "        \"rearrangement\",\n",
     "        \"double ph\",\n",
@@ -253,14 +241,14 @@
     "        \"k558np\",\n",
     "        \"exon\",\n",
     "    },\n",
-    "    VariantCategory.COPY_NUMBER: {\n",
+    "    NotSupportedVariantCategory.COPY_NUMBER: {\n",
     "        \"copy number\",\n",
     "        \"repeat\",\n",
     "        \"dup\",\n",
     "        \"non-amplification\",\n",
     "        \"gain\",\n",
     "    },\n",
-    "    VariantCategory.OTHER: {\n",
+    "    NotSupportedVariantCategory.OTHER: {\n",
     "        \"cytoplasmic mislocalization\",\n",
     "        \"alternative transcript\",\n",
     "        \"rare mutation\",\n",
@@ -283,7 +271,7 @@
     "        \"e151int\",\n",
     "        \"delnvtap\",\n",
     "    },\n",
-    "    VariantCategory.GENOTYPES: {\n",
+    "    NotSupportedVariantCategory.GENOTYPES: {\n",
     "        \"diplotypes\",\n",
     "        \"wild type\",\n",
     "        \"wildtype\",\n",
@@ -295,7 +283,7 @@
     "        \"loh\",\n",
     "        \"single allele deletion\",\n",
     "    },\n",
-    "    VariantCategory.REGION_DEFINED_VAR: {\n",
+    "    NotSupportedVariantCategory.REGION_DEFINED_VAR: {\n",
     "        \"deleterious mutation\",\n",
     "        \"domain mutation\",\n",
     "        \"polymorphism\",\n",
@@ -310,10 +298,231 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create functions to be used later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def _total_counts() -> dict:\n",
+    "    \"\"\"Return initial total counts for genomic and protein variants\"\"\"\n",
+    "    return {\n",
+    "        \"protein\": {\"accepted\": 0, \"submitted\": 0, \"count\": 0},\n",
+    "        \"genomic\": {\"accepted\": 0, \"submitted\": 0, \"count\": 0},\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "def is_accepted_variant(v: civicpy.Variant) -> bool:\n",
+    "    \"\"\"Return whether or not a variant (MPs) has at least one EID in an accepted status.\n",
+    "\n",
+    "    :param v: CIViC variant\n",
+    "    :return: `True` if considered accepted variant. `False` otherwise.\n",
+    "    \"\"\"\n",
+    "    for mp in v.molecular_profiles:\n",
+    "        for ev in mp.evidence_items:\n",
+    "            if ev.status == \"accepted\":\n",
+    "                return True\n",
+    "    return False\n",
+    "\n",
+    "\n",
+    "def get_variant_name_and_type(variant: civicpy.Variant) -> Tuple[Optional[str], str]:\n",
+    "    \"\"\"Get transformed variant name and type\n",
+    "\n",
+    "    :param variant: CIViC variant record\n",
+    "    :return: Tuple containing variant name to use in variation-normalizer (if found)\n",
+    "        and whether or not it's 'protein' or 'genomic' variant\n",
+    "    \"\"\"\n",
+    "    v_name = None\n",
+    "    v_q_type = None\n",
+    "\n",
+    "    if \"c.\" in variant.name:\n",
+    "        # Try getting genomic HGVS expression first\n",
+    "        v_name = (\n",
+    "            [expr for expr in variant.hgvs_expressions if \"g.\" in expr] or [None]\n",
+    "        )[0]\n",
+    "\n",
+    "        # If there is no genomic HGVS expression, try using gnomad vcf\n",
+    "        if not v_name:\n",
+    "            chromosome = variant.coordinates.chromosome\n",
+    "            pos = variant.coordinates.start\n",
+    "            ref = variant.coordinates.reference_bases\n",
+    "            alt = variant.coordinates.variant_bases\n",
+    "\n",
+    "            if all((chromosome, pos, ref, alt)):\n",
+    "                v_name = f\"{chromosome}-{pos}-{ref}-{alt}\"\n",
+    "\n",
+    "        v_q_type = \"genomic\"\n",
+    "    else:\n",
+    "        v_name = variant.name.strip()\n",
+    "        v_q_type = \"protein\"\n",
+    "\n",
+    "    return v_name, v_q_type\n",
+    "\n",
+    "\n",
+    "def translate_from_genomic(genomic_query: str) -> Dict:\n",
+    "    \"\"\"Try using vrs-python translate from using genomic query that failed to normalize\n",
+    "\n",
+    "    :param genomic_query: Genomic query (hgvs or gnomad VCF)\n",
+    "    :return: Response containing vrs_id (if successful) and errors (if unsuccessful)\n",
+    "    \"\"\"\n",
+    "    resp = {\"vrs_id\": None, \"error\": None}\n",
+    "    try:\n",
+    "        translate_from_resp = query_handler.vrs_python_tlr.translate_from(\n",
+    "            genomic_query, assembly_name=\"GRCh37\"\n",
+    "        )\n",
+    "    except Exception as e:\n",
+    "        resp[\"error\"] = str(e)\n",
+    "    else:\n",
+    "        resp[\"vrs_id\"] = translate_from_resp._id._value\n",
+    "\n",
+    "    return resp\n",
+    "\n",
+    "\n",
+    "def get_not_supported_categories(\n",
+    "    v_name: str, variant: civicpy.Variant\n",
+    ") -> Set[NotSupportedVariantCategory]:\n",
+    "    \"\"\"Get not supported categories for a CIViC variant.\n",
+    "\n",
+    "    :param v_name: Variant query to provide to the variation-normalizer\n",
+    "    :param variant: CIViC variant record\n",
+    "    :return: Set of associated NotSupportedVariantCategory for a variant. If supported,\n",
+    "        empty set will be returned\n",
+    "    \"\"\"\n",
+    "    v_name_lower = v_name.lower()\n",
+    "    categories = set()\n",
+    "\n",
+    "    if v_name_lower in {\"loss\", \"deletion\"}:\n",
+    "        categories.add(NotSupportedVariantCategory.GENE_FUNC)\n",
+    "    elif any(\n",
+    "        (\n",
+    "            v_name_lower in {\"mutation\", \"mutations\", \"snp\"},\n",
+    "            v_name_lower == f\"{variant.gene.name.lower()} mutation\",\n",
+    "        )\n",
+    "    ):\n",
+    "        categories.add(NotSupportedVariantCategory.REGION_DEFINED_VAR)\n",
+    "    else:\n",
+    "        if v_name_lower.endswith(\"deletion and mutation\"):\n",
+    "            v_name_split = v_name.split()\n",
+    "            if len(v_name_split) == 4:\n",
+    "                if (\n",
+    "                    query_handler.normalize_handler.gene_normalizer.normalize(\n",
+    "                        v_name_split[0]\n",
+    "                    ).match_type\n",
+    "                    > 0\n",
+    "                ):\n",
+    "                    categories.add(NotSupportedVariantCategory.REGION_DEFINED_VAR)\n",
+    "\n",
+    "        if re.match(r\".*e\\d+-e\\d+\", v_name_lower):  # ex: e20-e20\n",
+    "            categories.add(NotSupportedVariantCategory.FUSION)\n",
+    "\n",
+    "        if re.match(r\"intron\\s\\d+\\smutation\", v_name_lower):  # ex: Intron 6 Mutation\n",
+    "            categories.add(NotSupportedVariantCategory.REGION_DEFINED_VAR)\n",
+    "\n",
+    "        if any(\n",
+    "            (\n",
+    "                \"exon\" in v_name_lower,\n",
+    "                re.match(r\"t\\(.*\\)\\(.*\\)\", v_name_lower),  # ex: t(1;3)(p36.3;p25)\n",
+    "                re.match(r\".*ins$\", v_name_lower),  # ex: P780INS, L78_Q79ins\n",
+    "                re.match(\n",
+    "                    r\"\\w+_?\\w+>\\w+\", v_name_lower\n",
+    "                ),  # ex: 56_61QKQKVG>R, E746_T751>I, N771>GY\n",
+    "                re.match(r\"\\d+kb\\sdeletion\", v_name_lower),  # ex: 10kb Deletion\n",
+    "                re.match(\n",
+    "                    r\"partial\\sdeletion\\sof\\s\\d+(.\\d+)?\\skb\", v_name_lower\n",
+    "                ),  # ex: Partial deletion of 0.7 Kb\n",
+    "                re.match(\n",
+    "                    r\"\\d+(p|q)\\d+(.\\d+)?-\\d+(.\\d+)?\\s\\d+mb del\", v_name_lower\n",
+    "                ),  # ex: 3p26.3-25.3 11Mb del\n",
+    "            )\n",
+    "        ):\n",
+    "            categories.add(NotSupportedVariantCategory.REARRANGEMENTS)\n",
+    "\n",
+    "        if any(\n",
+    "            (\n",
+    "                re.match(r\"^rs\\d+\", v_name_lower),  # ex: RS11623866\n",
+    "                re.match(r\"class\\s\\d+\\smutation\", v_name_lower),  # ex: Class 3 Mutation\n",
+    "            )\n",
+    "        ):\n",
+    "            categories.add(NotSupportedVariantCategory.OTHER)\n",
+    "\n",
+    "        if re.match(r\"cd\\d+v?\\d+\", v_name_lower):  # cd44, cd44v6\n",
+    "            categories.add(NotSupportedVariantCategory.EXPRESSION)\n",
+    "\n",
+    "        if any(\n",
+    "            (\n",
+    "                re.match(r\"\\w+\\d+$\", v_name_lower),  # ex: V600\n",
+    "                re.match(r\"\\w+\\d+\\w+\\/\\w+$\", v_name_lower),  # ex: S893A/T\n",
+    "                re.match(\n",
+    "                    r\"[a-z]+\\d+[a-z]+\\sand\\s[a-z]+\\d+[a-z|*]+\", v_name_lower\n",
+    "                ),  # ex: E2014K and E2419K, R849W and R1108*\n",
+    "                re.match(r\"[a-z]+\\d+\\s&\\s[a-z]+\\d+\", v_name_lower),  # ex: D835 & I836\n",
+    "                re.match(\n",
+    "                    r\"[a-z]+\\d+[a-z]+\\sor\\s[a-z]+\\d+[a-z]+\", v_name_lower\n",
+    "                ),  # ex: H1047L or H1047R\n",
+    "                re.match(r\"\\w+\\d+\\smutations\", v_name_lower),  # ex: E1813 mutations\n",
+    "                re.match(\n",
+    "                    r\"\\d+\\s\\((c|a|g|t)+-(c|a|g|t)+\\)\", v_name_lower\n",
+    "                ),  # ex: 235 (CAG-TAG)\n",
+    "                re.match(r\"del\\s\\d+-\\d+\", v_name_lower),  # ex: DEL 485-490\n",
+    "            )\n",
+    "        ):\n",
+    "            categories.add(NotSupportedVariantCategory.SEQUENCE_VARS)\n",
+    "\n",
+    "        if any(\n",
+    "            (\n",
+    "                re.match(\n",
+    "                    r\"^\\w+\\samplification\", v_name_lower\n",
+    "                ),  # ex: {gene} amplification\n",
+    "                re.match(\n",
+    "                    r\"grch3(7|8)\\/hg\\d+\\s\\w+.?\\d*\\(chr\\w+:\\d+-\\d+\\)x\\d+\", v_name_lower\n",
+    "                ),  # ex: GRCh37/hg19 11q14.3(chr11:88960991-88961138)x160\n",
+    "            )\n",
+    "        ):\n",
+    "            categories.add(NotSupportedVariantCategory.COPY_NUMBER)\n",
+    "\n",
+    "        if re.match(r\"\\w+[^fs]\\*\\d+$\", v_name_lower):  # ex: UGT1A1*28\n",
+    "            categories.add(NotSupportedVariantCategory.GENOTYPES)\n",
+    "\n",
+    "        for k, v in not_supported.items():\n",
+    "            if {x for x in v if x in v_name_lower}:\n",
+    "                categories.add(k)\n",
+    "\n",
+    "    if len(categories) > 1:\n",
+    "        # Those with multiple categories will be classified as other\n",
+    "        categories = {NotSupportedVariantCategory.OTHER}\n",
+    "\n",
+    "    return categories"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create files"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "92"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# This file contains protein queries (gene + variant_name) we SHOULD be able to\n",
     "# normalize\n",
@@ -331,8 +540,8 @@
     "    ]\n",
     ")\n",
     "\n",
-    "# This file contains genomic queries (genomic HGVS expressions) we SHOULD be able to\n",
-    "# normalize\n",
+    "# This file contains genomic queries (genomic HGVS expressions or gnomad VCF) we SHOULD\n",
+    "# be able to normalize\n",
     "genomic_variants_wf = open(\n",
     "    \"should_be_able_to_normalize_genomic_variant_queries.csv\", \"w\"\n",
     ")\n",
@@ -356,7 +565,8 @@
     "    ]\n",
     ")\n",
     "\n",
-    "# This file contains CIViC Variant queries that we were not able to normalize.\n",
+    "# This file contains CIViC Variant queries that were run through Variation Normalizer,\n",
+    "# but failed to normalize.\n",
     "unable_to_normalize_wf = open(\"unable_to_normalize_queries.csv\", \"w\")\n",
     "unable_to_normalize_wr = csv.writer(unable_to_normalize_wf, delimiter=\"\\t\")\n",
     "unable_to_normalize_wr.writerow(\n",
@@ -372,7 +582,8 @@
     "    ]\n",
     ")\n",
     "\n",
-    "# This file contains CIViC Variant queries that we were able to normalize.\n",
+    "# This file contains CIViC Variant queries that were run through variation normalizer,\n",
+    "# and successfully normalized\n",
     "able_to_normalize_wf = open(\"able_to_normalize_queries.csv\", \"w\")\n",
     "able_to_normalize_wr = csv.writer(able_to_normalize_wf, delimiter=\"\\t\")\n",
     "able_to_normalize_wr.writerow(\n",
@@ -385,19 +596,24 @@
     "        \"vrs_id\",\n",
     "        \"succeeded_endpoint\",\n",
     "    ]\n",
-    ")\n",
-    "\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create variables to store information, such as counts, that will be used later"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Category name for variants we do not support: number of variants we found\n",
-    "variant_category_counts = {c: 0 for c in VariantCategory.__members__}\n",
-    "\n",
-    "\n",
-    "def _total_counts():\n",
-    "    \"\"\"Return initial total counts for genomic and protein variants\"\"\"\n",
-    "    return {\n",
-    "        \"protein\": {\"accepted\": 0, \"submitted\": 0, \"count\": 0},\n",
-    "        \"genomic\": {\"accepted\": 0, \"submitted\": 0, \"count\": 0},\n",
-    "    }\n",
-    "\n",
+    "variant_category_counts = {c: 0 for c in NotSupportedVariantCategory.__members__}\n",
     "\n",
     "# Keep track of total counts\n",
     "should_be_able_to_normalize_total = _total_counts()\n",
@@ -406,36 +622,17 @@
     "exception_total = _total_counts()\n",
     "genomic_translate_from_success = 0\n",
     "\n",
-    "queries_found = dict()\n",
-    "\n",
-    "\n",
-    "def is_accepted_variant(v) -> bool:\n",
-    "    \"\"\"Return whether or not a variant (MP) has at least one EID in an accepted status.\"\"\"\n",
-    "    for mp in v.molecular_profiles:\n",
-    "        for ev in mp.evidence_items:\n",
-    "            if ev.status == \"accepted\":\n",
-    "                return True\n",
-    "    return False\n",
-    "\n",
-    "\n",
-    "def translate_from_genomic(genomic_query: str) -> dict:\n",
-    "    \"\"\"Try using vrs-python translate from using genomic query that failed to normalize\"\"\"\n",
-    "    resp = {\"vrs_id\": None, \"error\": None}\n",
-    "    try:\n",
-    "        translate_from_resp = query_handler.vrs_python_tlr.translate_from(\n",
-    "            genomic_query, assembly_name=\"GRCh37\"\n",
-    "        )\n",
-    "    except Exception as e:\n",
-    "        resp[\"error\"] = str(e)\n",
-    "    else:\n",
-    "        resp[\"vrs_id\"] = translate_from_resp._id._value\n",
-    "\n",
-    "    return resp\n",
-    "\n",
-    "\n",
-    "for variant in variants:\n",
-    "    v_name = None\n",
-    "    v_q_type = None\n",
+    "# Used to find duplicate queries\n",
+    "queries_found = dict()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for variant in acc_sub_variants:\n",
     "    civic_variant_types = (\n",
     "        \";\".join([v.name for v in variant.variant_types]) or \"Not provided\"\n",
     "    )\n",
@@ -448,31 +645,12 @@
     "        \"accepted\" if is_accepted else \"submitted\"\n",
     "    )  # used in total counts dicts\n",
     "\n",
-    "    if \"c.\" in variant.name:\n",
-    "        # Try getting genomic HGVS expression first\n",
-    "        v_name = (\n",
-    "            [expr for expr in variant.hgvs_expressions if \"g.\" in expr] or [None]\n",
-    "        )[0]\n",
-    "\n",
-    "        # If there is no genomic HGVS expression, try using gnomad vcf\n",
-    "        if not v_name:\n",
-    "            chromosome = variant.coordinates.chromosome\n",
-    "            pos = variant.coordinates.start\n",
-    "            ref = variant.coordinates.reference_bases\n",
-    "            alt = variant.coordinates.variant_bases\n",
-    "\n",
-    "            if all((chromosome, pos, ref, alt)):\n",
-    "                v_name = f\"{chromosome}-{pos}-{ref}-{alt}\"\n",
-    "\n",
-    "        v_q_type = \"genomic\"\n",
-    "    else:\n",
-    "        v_name = variant.name.strip()\n",
-    "        v_q_type = \"protein\"\n",
-    "\n",
+    "    # Get variant name and type\n",
+    "    v_name, v_q_type = get_variant_name_and_type(variant)\n",
     "    gene_name = variant.gene.name.strip()\n",
     "\n",
     "    if not v_name:\n",
-    "        variant_category_name = VariantCategory.TRANSCRIPT_VAR\n",
+    "        variant_category_name = NotSupportedVariantCategory.TRANSCRIPT_VAR\n",
     "        variant_category_counts[variant_category_name.name] += 1\n",
     "        not_supported_wr.writerow(\n",
     "            [\n",
@@ -486,111 +664,11 @@
     "        )\n",
     "        continue\n",
     "\n",
-    "    v_name_lower = v_name.lower()\n",
+    "    # Determine if variant is not supported\n",
+    "    not_supported_categories = get_not_supported_categories(v_name, variant)\n",
     "\n",
-    "    categories = set()\n",
-    "    if v_name_lower in {\"loss\", \"deletion\"}:\n",
-    "        categories.add(VariantCategory.GENE_FUNC)\n",
-    "    elif any(\n",
-    "        (\n",
-    "            v_name_lower in {\"mutation\", \"mutations\", \"snp\"},\n",
-    "            v_name_lower == f\"{variant.gene.name.lower()} mutation\",\n",
-    "        )\n",
-    "    ):\n",
-    "        categories.add(VariantCategory.REGION_DEFINED_VAR)\n",
-    "    else:\n",
-    "        if v_name_lower.endswith(\"deletion and mutation\"):\n",
-    "            v_name_split = v_name.split()\n",
-    "            if len(v_name_split) == 4:\n",
-    "                if (\n",
-    "                    query_handler.normalize_handler.gene_normalizer.normalize(\n",
-    "                        v_name_split[0]\n",
-    "                    ).match_type\n",
-    "                    > 0\n",
-    "                ):\n",
-    "                    categories.add(VariantCategory.REGION_DEFINED_VAR)\n",
-    "\n",
-    "        if re.match(r\".*e\\d+-e\\d+\", v_name_lower):  # ex: e20-e20\n",
-    "            categories.add(VariantCategory.FUSION)\n",
-    "\n",
-    "        if re.match(r\"intron\\s\\d+\\smutation\", v_name_lower):  # ex: Intron 6 Mutation\n",
-    "            categories.add(VariantCategory.REGION_DEFINED_VAR)\n",
-    "\n",
-    "        if any(\n",
-    "            (\n",
-    "                \"exon\" in v_name_lower,\n",
-    "                re.match(r\"t\\(.*\\)\\(.*\\)\", v_name_lower),  # ex: t(1;3)(p36.3;p25)\n",
-    "                re.match(r\".*ins$\", v_name_lower),  # ex: P780INS, L78_Q79ins\n",
-    "                re.match(\n",
-    "                    r\"\\w+_?\\w+>\\w+\", v_name_lower\n",
-    "                ),  # ex: 56_61QKQKVG>R, E746_T751>I, N771>GY\n",
-    "                re.match(r\"\\d+kb\\sdeletion\", v_name_lower),  # ex: 10kb Deletion\n",
-    "                re.match(\n",
-    "                    r\"partial\\sdeletion\\sof\\s\\d+(.\\d+)?\\skb\", v_name_lower\n",
-    "                ),  # ex: Partial deletion of 0.7 Kb\n",
-    "                re.match(\n",
-    "                    r\"\\d+(p|q)\\d+(.\\d+)?-\\d+(.\\d+)?\\s\\d+mb del\", v_name_lower\n",
-    "                ),  # ex: 3p26.3-25.3 11Mb del\n",
-    "            )\n",
-    "        ):\n",
-    "            categories.add(VariantCategory.REARRANGEMENTS)\n",
-    "\n",
-    "        if any(\n",
-    "            (\n",
-    "                re.match(r\"^rs\\d+\", v_name_lower),  # ex: RS11623866\n",
-    "                re.match(r\"class\\s\\d+\\smutation\", v_name_lower),  # ex: Class 3 Mutation\n",
-    "            )\n",
-    "        ):\n",
-    "            categories.add(VariantCategory.OTHER)\n",
-    "\n",
-    "        if re.match(r\"cd\\d+v?\\d+\", v_name_lower):  # cd44, cd44v6\n",
-    "            categories.add(VariantCategory.EXPRESSION)\n",
-    "\n",
-    "        if any(\n",
-    "            (\n",
-    "                re.match(r\"\\w+\\d+$\", v_name_lower),  # ex: V600\n",
-    "                re.match(r\"\\w+\\d+\\w+\\/\\w+$\", v_name_lower),  # ex: S893A/T\n",
-    "                re.match(\n",
-    "                    r\"[a-z]+\\d+[a-z]+\\sand\\s[a-z]+\\d+[a-z|*]+\", v_name_lower\n",
-    "                ),  # ex: E2014K and E2419K, R849W and R1108*\n",
-    "                re.match(r\"[a-z]+\\d+\\s&\\s[a-z]+\\d+\", v_name_lower),  # ex: D835 & I836\n",
-    "                re.match(\n",
-    "                    r\"[a-z]+\\d+[a-z]+\\sor\\s[a-z]+\\d+[a-z]+\", v_name_lower\n",
-    "                ),  # ex: H1047L or H1047R\n",
-    "                re.match(r\"\\w+\\d+\\smutations\", v_name_lower),  # ex: E1813 mutations\n",
-    "                re.match(\n",
-    "                    r\"\\d+\\s\\((c|a|g|t)+-(c|a|g|t)+\\)\", v_name_lower\n",
-    "                ),  # ex: 235 (CAG-TAG)\n",
-    "                re.match(r\"del\\s\\d+-\\d+\", v_name_lower),  # ex: DEL 485-490\n",
-    "            )\n",
-    "        ):\n",
-    "            categories.add(VariantCategory.SEQUENCE_VARS)\n",
-    "\n",
-    "        if any(\n",
-    "            (\n",
-    "                re.match(\n",
-    "                    r\"^\\w+\\samplification\", v_name_lower\n",
-    "                ),  # ex: {gene} amplification\n",
-    "                re.match(\n",
-    "                    r\"grch3(7|8)\\/hg\\d+\\s\\w+.?\\d*\\(chr\\w+:\\d+-\\d+\\)x\\d+\", v_name_lower\n",
-    "                ),  # ex: GRCh37/hg19 11q14.3(chr11:88960991-88961138)x160\n",
-    "            )\n",
-    "        ):\n",
-    "            categories.add(VariantCategory.COPY_NUMBER)\n",
-    "\n",
-    "        if re.match(r\"\\w+[^fs]\\*\\d+$\", v_name_lower):  # ex: UGT1A1*28\n",
-    "            categories.add(VariantCategory.GENOTYPES)\n",
-    "\n",
-    "        for k, v in not_supported.items():\n",
-    "            if {x for x in v if x in v_name_lower}:\n",
-    "                categories.add(k)\n",
-    "\n",
-    "    if len(categories) > 1:\n",
-    "        # Those with multiple categories will be classified as other\n",
-    "        categories = {VariantCategory.OTHER}\n",
-    "\n",
-    "    if len(categories) == 1:\n",
-    "        variant_category_name = categories.pop()\n",
+    "    if len(not_supported_categories) == 1:\n",
+    "        variant_category_name = not_supported_categories.pop()\n",
     "        variant_category_counts[variant_category_name.name] += 1\n",
     "        not_supported_wr.writerow(\n",
     "            [\n",
@@ -602,115 +680,100 @@
     "                is_accepted,\n",
     "            ]\n",
     "        )\n",
+    "        continue\n",
+    "\n",
+    "    # We should support this, so we need to query the variation normalizer\n",
+    "    if v_q_type == \"protein\":\n",
+    "        q = f\"{gene_name} {v_name}\"\n",
+    "        protein_variants_wr.writerow(\n",
+    "            [variant.id, gene_name, v_name, is_accepted, civic_variant_types]\n",
+    "        )\n",
     "    else:\n",
-    "        # We should support this, so we need to query the variation normalizer\n",
-    "        if v_q_type == \"protein\":\n",
-    "            q = f\"{gene_name} {v_name}\"\n",
-    "            protein_variants_wr.writerow(\n",
-    "                [variant.id, gene_name, v_name, is_accepted, civic_variant_types]\n",
-    "            )\n",
-    "        else:\n",
-    "            q = v_name\n",
-    "            genomic_variants_wr.writerow(\n",
-    "                [variant.id, q, is_accepted, civic_variant_types]\n",
-    "            )\n",
+    "        q = v_name\n",
+    "        genomic_variants_wr.writerow([variant.id, q, is_accepted, civic_variant_types])\n",
     "\n",
-    "        should_be_able_to_normalize_total[v_q_type][\"count\"] += 1\n",
-    "        should_be_able_to_normalize_total[v_q_type][accepted_key] += 1\n",
+    "    should_be_able_to_normalize_total[v_q_type][\"count\"] += 1\n",
+    "    should_be_able_to_normalize_total[v_q_type][accepted_key] += 1\n",
     "\n",
-    "        if q in queries_found:\n",
-    "            queries_found[q].append(variant.id)\n",
-    "        else:\n",
-    "            queries_found[q] = [variant.id]\n",
+    "    if q in queries_found:\n",
+    "        queries_found[q].append(variant.id)\n",
+    "    else:\n",
+    "        queries_found[q] = [variant.id]\n",
     "\n",
-    "        try:\n",
-    "            variation_norm_resp = await query_handler.normalize_handler.normalize(\n",
-    "                q, input_assembly=ClinVarAssembly.GRCH37\n",
-    "            )\n",
-    "            if not variation_norm_resp.variation_descriptor:\n",
-    "                if v_q_type == \"protein\" and len(v_name.split()) == 1:\n",
-    "                    if \"-\" in v_name:\n",
-    "                        # could be {gene}-{gene}\n",
-    "                        genes = v_name.split(\"-\")\n",
-    "                        variant_category_name = VariantCategory.FUSION\n",
-    "                    else:\n",
-    "                        # Just a gene name\n",
-    "                        genes = [v_name]\n",
-    "                        variant_category_name = VariantCategory.OTHER\n",
-    "\n",
-    "                    is_genes = True\n",
-    "                    for g in genes:\n",
-    "                        if (\n",
-    "                            query_handler.normalize_handler.gene_normalizer.normalize(\n",
-    "                                g\n",
-    "                            ).match_type\n",
-    "                            == 0\n",
-    "                        ):\n",
-    "                            # not a gene\n",
-    "                            is_genes = False\n",
-    "                            break\n",
-    "\n",
-    "                    if is_genes:\n",
-    "                        variant_category_counts[variant_category_name.name] += 1\n",
-    "                        not_supported_wr.writerow(\n",
-    "                            [\n",
-    "                                variant.id,\n",
-    "                                gene_name,\n",
-    "                                variant.name,\n",
-    "                                civic_variant_types,\n",
-    "                                variant_category_name,\n",
-    "                                is_accepted,\n",
-    "                            ]\n",
-    "                        )\n",
-    "                        continue\n",
-    "\n",
-    "                no_vrs_id = True\n",
-    "                warnings = variation_norm_resp.warnings or []\n",
-    "\n",
-    "                # Try running genomic queries through vrs-python translate from\n",
-    "                if v_q_type == \"genomic\":\n",
-    "                    genomic_resp = translate_from_genomic(q)\n",
-    "\n",
-    "                    if genomic_resp[\"vrs_id\"]:\n",
-    "                        genomic_translate_from_success += 1\n",
-    "                        no_vrs_id = False\n",
-    "                        vrs_id = genomic_resp[\"vrs_id\"]\n",
-    "                    else:\n",
-    "                        warnings.append(genomic_resp[\"error\"])\n",
-    "\n",
-    "                if no_vrs_id:\n",
-    "                    unable_to_normalize_wr.writerow(\n",
-    "                        [\n",
-    "                            variant.id,\n",
-    "                            q,\n",
-    "                            v_q_type,\n",
-    "                            is_accepted,\n",
-    "                            civic_variant_types,\n",
-    "                            False,\n",
-    "                            \"unable to normalize\",\n",
-    "                            sorted(warnings),\n",
-    "                        ]\n",
-    "                    )\n",
-    "                    unable_to_normalize_total[v_q_type][\"count\"] += 1\n",
-    "                    unable_to_normalize_total[v_q_type][accepted_key] += 1\n",
+    "    try:\n",
+    "        variation_norm_resp = await query_handler.normalize_handler.normalize(\n",
+    "            q, input_assembly=ClinVarAssembly.GRCH37\n",
+    "        )\n",
+    "        if not variation_norm_resp.variation_descriptor:\n",
+    "            if v_q_type == \"protein\" and len(v_name.split()) == 1:\n",
+    "                # Determine if fusion or gene name (which actually aren't supported)\n",
+    "                if \"-\" in v_name:\n",
+    "                    # could be {gene}-{gene}\n",
+    "                    genes = v_name.split(\"-\")\n",
+    "                    variant_category_name = NotSupportedVariantCategory.FUSION\n",
     "                else:\n",
-    "                    can_normalize_total[v_q_type][\"count\"] += 1\n",
-    "                    can_normalize_total[v_q_type][accepted_key] += 1\n",
-    "                    able_to_normalize_wr.writerow(\n",
+    "                    # Just a gene name\n",
+    "                    genes = [v_name]\n",
+    "                    variant_category_name = NotSupportedVariantCategory.OTHER\n",
+    "\n",
+    "                is_genes = True\n",
+    "                for g in genes:\n",
+    "                    if (\n",
+    "                        query_handler.normalize_handler.gene_normalizer.normalize(\n",
+    "                            g\n",
+    "                        ).match_type\n",
+    "                        == 0\n",
+    "                    ):\n",
+    "                        # not a gene\n",
+    "                        is_genes = False\n",
+    "                        break\n",
+    "\n",
+    "                if is_genes:\n",
+    "                    variant_category_counts[variant_category_name.name] += 1\n",
+    "                    not_supported_wr.writerow(\n",
     "                        [\n",
     "                            variant.id,\n",
-    "                            q,\n",
-    "                            v_q_type,\n",
-    "                            is_accepted,\n",
+    "                            gene_name,\n",
+    "                            variant.name,\n",
     "                            civic_variant_types,\n",
-    "                            vrs_id,\n",
-    "                            \"translate_from\",\n",
+    "                            variant_category_name,\n",
+    "                            is_accepted,\n",
     "                        ]\n",
     "                    )\n",
+    "                    continue\n",
+    "\n",
+    "            no_vrs_id = True\n",
+    "            warnings = variation_norm_resp.warnings or []\n",
+    "\n",
+    "            # Try running genomic queries through vrs-python translate from\n",
+    "            if v_q_type == \"genomic\":\n",
+    "                genomic_resp = translate_from_genomic(q)\n",
+    "\n",
+    "                if genomic_resp[\"vrs_id\"]:\n",
+    "                    genomic_translate_from_success += 1\n",
+    "                    no_vrs_id = False\n",
+    "                    vrs_id = genomic_resp[\"vrs_id\"]\n",
+    "                else:\n",
+    "                    warnings.append(genomic_resp[\"error\"])\n",
+    "\n",
+    "            if no_vrs_id:\n",
+    "                unable_to_normalize_wr.writerow(\n",
+    "                    [\n",
+    "                        variant.id,\n",
+    "                        q,\n",
+    "                        v_q_type,\n",
+    "                        is_accepted,\n",
+    "                        civic_variant_types,\n",
+    "                        False,\n",
+    "                        \"unable to normalize\",\n",
+    "                        sorted(warnings),\n",
+    "                    ]\n",
+    "                )\n",
+    "                unable_to_normalize_total[v_q_type][\"count\"] += 1\n",
+    "                unable_to_normalize_total[v_q_type][accepted_key] += 1\n",
     "            else:\n",
     "                can_normalize_total[v_q_type][\"count\"] += 1\n",
     "                can_normalize_total[v_q_type][accepted_key] += 1\n",
-    "                vrs_id = variation_norm_resp.variation_descriptor.variation.id\n",
     "                able_to_normalize_wr.writerow(\n",
     "                    [\n",
     "                        variant.id,\n",
@@ -719,56 +782,76 @@
     "                        is_accepted,\n",
     "                        civic_variant_types,\n",
     "                        vrs_id,\n",
-    "                        \"normalize\",\n",
+    "                        \"translate_from\",\n",
     "                    ]\n",
     "                )\n",
-    "        except Exception as e:\n",
-    "            warnings = [str(e)]\n",
-    "\n",
-    "            # Try running genomic queries through vrs-python translate from\n",
-    "            if v_q_type == \"genomic\":\n",
-    "                genomic_resp = translate_from_genomic(q)\n",
-    "\n",
-    "                if genomic_resp[\"vrs_id\"]:\n",
-    "                    vrs_id = genomic_resp[\"vrs_id\"]\n",
-    "                else:\n",
-    "                    vrs_id = None\n",
-    "                    warnings.append(genomic_resp[\"error\"])\n",
-    "\n",
-    "                if vrs_id:\n",
-    "                    genomic_translate_from_success += 1\n",
-    "                    can_normalize_total[v_q_type][\"count\"] += 1\n",
-    "                    can_normalize_total[v_q_type][accepted_key] += 1\n",
-    "                    vrs_id = variation_norm_resp.variation_descriptor.variation.id\n",
-    "                    able_to_normalize_wr.writerow(\n",
-    "                        [\n",
-    "                            variant.id,\n",
-    "                            q,\n",
-    "                            v_q_type,\n",
-    "                            is_accepted,\n",
-    "                            civic_variant_types,\n",
-    "                            vrs_id,\n",
-    "                            \"translate_from\",\n",
-    "                        ]\n",
-    "                    )\n",
-    "\n",
-    "                    continue\n",
-    "\n",
-    "            unable_to_normalize_wr.writerow(\n",
+    "        else:\n",
+    "            can_normalize_total[v_q_type][\"count\"] += 1\n",
+    "            can_normalize_total[v_q_type][accepted_key] += 1\n",
+    "            vrs_id = variation_norm_resp.variation_descriptor.variation.id\n",
+    "            able_to_normalize_wr.writerow(\n",
     "                [\n",
     "                    variant.id,\n",
     "                    q,\n",
     "                    v_q_type,\n",
     "                    is_accepted,\n",
     "                    civic_variant_types,\n",
-    "                    True,\n",
-    "                    sorted(warnings),\n",
-    "                    None,\n",
+    "                    vrs_id,\n",
+    "                    \"normalize\",\n",
     "                ]\n",
     "            )\n",
-    "            exception_total[v_q_type][\"count\"] += 1\n",
-    "            exception_total[v_q_type][accepted_key] += 1\n",
+    "    except Exception as e:\n",
+    "        warnings = [str(e)]\n",
     "\n",
+    "        # Try running genomic queries through vrs-python translate from\n",
+    "        if v_q_type == \"genomic\":\n",
+    "            genomic_resp = translate_from_genomic(q)\n",
+    "\n",
+    "            if genomic_resp[\"vrs_id\"]:\n",
+    "                vrs_id = genomic_resp[\"vrs_id\"]\n",
+    "            else:\n",
+    "                vrs_id = None\n",
+    "                warnings.append(genomic_resp[\"error\"])\n",
+    "\n",
+    "            if vrs_id:\n",
+    "                genomic_translate_from_success += 1\n",
+    "                can_normalize_total[v_q_type][\"count\"] += 1\n",
+    "                can_normalize_total[v_q_type][accepted_key] += 1\n",
+    "                able_to_normalize_wr.writerow(\n",
+    "                    [\n",
+    "                        variant.id,\n",
+    "                        q,\n",
+    "                        v_q_type,\n",
+    "                        is_accepted,\n",
+    "                        civic_variant_types,\n",
+    "                        vrs_id,\n",
+    "                        \"translate_from\",\n",
+    "                    ]\n",
+    "                )\n",
+    "                continue\n",
+    "\n",
+    "        unable_to_normalize_wr.writerow(\n",
+    "            [\n",
+    "                variant.id,\n",
+    "                q,\n",
+    "                v_q_type,\n",
+    "                is_accepted,\n",
+    "                civic_variant_types,\n",
+    "                True,\n",
+    "                sorted(warnings),\n",
+    "                None,\n",
+    "            ]\n",
+    "        )\n",
+    "        exception_total[v_q_type][\"count\"] += 1\n",
+    "        exception_total[v_q_type][accepted_key] += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Close all files\n",
     "protein_variants_wf.close()\n",
     "genomic_variants_wf.close()\n",
@@ -787,7 +870,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -804,7 +887,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -823,7 +906,7 @@
        " 'EPIGENETIC_MODIFICATION': 14}"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -845,7 +928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -864,38 +947,41 @@
        " 'EPIGENETIC_MODIFICATION': '0.40%'}"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "{k: f\"{v / total_variants * 100:.2f}%\" for k, v in sorted_variant_cat_counts.items()}"
+    "{\n",
+    "    k: f\"{v / len_acc_sub_variants * 100:.2f}%\"\n",
+    "    for k, v in sorted_variant_cat_counts.items()\n",
+    "}"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer does not support 44.42% of the total variants'"
+       "'The Variation Normalizer does not support 44.42% of the total accepted and submitted variants'"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer does not support {do_not_support_total_sum / total_variants * 100:.2f}% of the total variants\""
+    "f\"The Variation Normalizer does not support {do_not_support_total_sum / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -904,7 +990,7 @@
        "'Total number of variants we do not support in the Variation Normalizer: 1563'"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -923,7 +1009,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
@@ -933,7 +1019,7 @@
        " 'genomic': {'accepted': 245, 'submitted': 181, 'count': 426}}"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -944,7 +1030,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -953,7 +1039,7 @@
        "1961"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -968,7 +1054,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -977,7 +1063,7 @@
        "'44.98% of these are accepted variants'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -992,7 +1078,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
@@ -1001,7 +1087,7 @@
        "'55.02% of these are submitted variants'"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1016,22 +1102,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer SHOULD be able to normalize 55.73% of the total variants'"
+       "'The Variation Normalizer SHOULD be able to normalize 55.73% of the total accepted and submitted variants'"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer SHOULD be able to normalize {should_be_able_to_normalize_total_sum / total_variants * 100:.2f}% of the total variants\""
+    "f\"The Variation Normalizer SHOULD be able to normalize {should_be_able_to_normalize_total_sum / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants\""
    ]
   },
   {
@@ -1046,7 +1132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -1056,7 +1142,7 @@
        " 'genomic': {'accepted': 0, 'submitted': 0, 'count': 0}}"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1067,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -1076,7 +1162,7 @@
        "80"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1091,7 +1177,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -1100,7 +1186,7 @@
        "'13.75% of these are accepted variants'"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1115,7 +1201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -1124,7 +1210,7 @@
        "'86.25% of these are submitted variants'"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1139,22 +1225,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer was unable to normalize 2.27% of the total variants'"
+       "'The Variation Normalizer was unable to normalize 2.27% of the total accepted and submitted variants'"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer was unable to normalize {unable_to_normalize_total_sum / total_variants * 100:.2f}% of the total variants\""
+    "f\"The Variation Normalizer was unable to normalize {unable_to_normalize_total_sum / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants\""
    ]
   },
   {
@@ -1169,7 +1255,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,22 +1286,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer found 0 invalid variants (This is 0.00% of the total variants).'"
+       "'The Variation Normalizer found 0 invalid variants (This is 0.00% of the total accepted and submitted variants).'"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer found {unable_to_find_valid} invalid variants (This is {unable_to_find_valid / total_variants * 100:.2f}% of the total variants).\""
+    "f\"The Variation Normalizer found {unable_to_find_valid} invalid variants (This is {unable_to_find_valid / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants).\""
    ]
   },
   {
@@ -1230,42 +1316,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer was unable to tokenize 26 variants (0.74% of the total variants).'"
+       "'The Variation Normalizer was unable to tokenize 26 variants (0.74% of the total accepted and submitted variants).'"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer was unable to tokenize {unable_to_tokenize} variants ({unable_to_tokenize / total_variants * 100:.2f}% of the total variants).\""
+    "f\"The Variation Normalizer was unable to tokenize {unable_to_tokenize} variants ({unable_to_tokenize / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants).\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer was unable to normalize 54 variants due to other issues (This is 1.53% of the total variants).'"
+       "'The Variation Normalizer was unable to normalize 54 variants due to other issues (This is 1.53% of the total accepted and submitted variants).'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer was unable to normalize {other} variants due to other issues (This is {other / total_variants * 100:.2f}% of the total variants).\""
+    "f\"The Variation Normalizer was unable to normalize {other} variants due to other issues (This is {other / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants).\""
    ]
   },
   {
@@ -1278,7 +1364,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1288,7 +1374,7 @@
        " 'genomic': {'accepted': 0, 'submitted': 0, 'count': 0}}"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1299,7 +1385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1308,7 +1394,7 @@
        "0"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1322,22 +1408,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer raised an exception for 0.00% of the total variants'"
+       "'The Variation Normalizer raised an exception for 0.00% of the total accepted and submitted variants'"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer raised an exception for {exception_total_sum / total_variants * 100:.2f}% of the total variants\""
+    "f\"The Variation Normalizer raised an exception for {exception_total_sum / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants\""
    ]
   },
   {
@@ -1350,7 +1436,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
@@ -1360,7 +1446,7 @@
        " 'genomic': {'accepted': 245, 'submitted': 181, 'count': 426}}"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1371,7 +1457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1380,7 +1466,7 @@
        "1876"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1394,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1403,7 +1489,7 @@
        "'46.32% of these are accepted variants'"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1418,7 +1504,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -1427,7 +1513,7 @@
        "'53.68% of these are submitted variants'"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1442,7 +1528,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1451,7 +1537,7 @@
        "'The Variation Normalizer successfully normalized 95.67% of the variants we SHOULD be able to normalize'"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1462,27 +1548,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'The Variation Normalizer successfully normalized 53.31% of the total variants'"
+       "'The Variation Normalizer successfully normalized 53.31% of the total accepted and submitted variants'"
       ]
      },
-     "execution_count": 38,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "f\"The Variation Normalizer successfully normalized {can_normalize_total_sum / total_variants * 100:.2f}% of the total variants\""
+    "f\"The Variation Normalizer successfully normalized {can_normalize_total_sum / len_acc_sub_variants * 100:.2f}% of the total accepted and submitted variants\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -1491,7 +1577,7 @@
        "'The Variation Normalizer was not able to normalize 1 genomic variants (count) but vrs-python translate was. These were included in the able to normalize total.'"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1512,7 +1598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
@@ -1524,7 +1610,7 @@
        " 'BRAF V600R': [16, 991]}"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1532,13 +1618,6 @@
    "source": [
     "{k: v for k, v in queries_found.items() if len(v) > 1}"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -1557,7 +1636,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.3"
+   "version": "3.11.5"
   },
   "orig_nbformat": 4,
   "vscode": {


### PR DESCRIPTION
Close #53 and #47

Notes:
* Clean up civic variation analysis nb (refactoring / docstrings / comments)
* Fix naming for "total variants". We're actually talking about accepted and submitted variants, so renamed to `acc_sub_variants`. 
* Renames `VariantCategory` to `NotSupportedVariantCategory` since these are only categories for variants we do not support
